### PR TITLE
Fix check for existing work dir

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -42,8 +42,6 @@ async fn main() -> Result<()> {
             }
         }
         cli::Command::UpdateRepo => {
-            fs::create_dir_all(&work_dir).await?;
-
             if work_dir.exists() {
                 tokio::process::Command::new("git")
                     .args(["pull", "--recurse-submodules"])
@@ -53,6 +51,8 @@ async fn main() -> Result<()> {
                     .await
                     .context("failed to pull extensions repository")?;
             } else {
+                fs::create_dir_all(&work_dir).await?;
+
                 tokio::process::Command::new("git")
                     .args(["clone", "--recurse-submodules", extension_repository_url])
                     .arg(&work_dir)


### PR DESCRIPTION
Currently, the work directory is always first created and then checked for existance. This causes the update-command to not work on the first invocation when the repositories were not yet cloned.

This PR fixes this behaviour by first checking whether the work directory already exists and then only creating it if does not already.
