### PR TITLE
Add support for surveying nested property values

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -26,7 +26,7 @@ pub enum SurveyCommand {
     /// A survey to find extensions using a particular theme property.
     ThemeProperty {
         /// The name of the theme property to survey.
-        name: String,
+        name: Vec<String>,
     },
     /// A survey to find extensions still using the legacy `extension.json` manifest format.
     ExtensionJson,

--- a/src/extensions.rs
+++ b/src/extensions.rs
@@ -53,5 +53,5 @@ pub struct ThemeFamily {
 #[derive(Debug, Deserialize)]
 pub struct Theme {
     pub name: String,
-    pub style: BTreeMap<String, serde_json::Value>,
+    pub style: serde_json::Value,
 }


### PR DESCRIPTION
This PR adds support for querying nested values in themes. Given the context of deprecation-warnings, this might not make that much sense. However, locally I used this to check whether some properties are defined in themes at all. Should that be something that you are interested in, I would add proper support for that 😄 Long-term, I suppose it might be more interesting to just collect such usage information across all themes for all properties though.


I also changed the loading of the JSON-files given https://github.com/serde-rs/json/issues/160#issuecomment-253446892. For me, this reduces the time it takes for a survey to complete from 4.5 seconds to around 450ms.